### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -5,6 +5,9 @@ on:
     - cron: "5 4 * * *"   # JST 13:05 (UTC 04:05)
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   daily-graph:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/clockcrockwork/ccc-summary-dashboard/security/code-scanning/3](https://github.com/clockcrockwork/ccc-summary-dashboard/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly limit the `GITHUB_TOKEN` permissions to `contents: read`, which is sufficient for the workflow's needs (e.g., fetching a file from the repository). This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
