### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rotate-trigger.yml
+++ b/.github/workflows/rotate-trigger.yml
@@ -5,6 +5,9 @@ on:
     - cron: "55 23 28-31 * *"   # 月末23:55 JST
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   rollup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/clockcrockwork/ccc-summary-dashboard/security/code-scanning/2](https://github.com/clockcrockwork/ccc-summary-dashboard/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required for the `GITHUB_TOKEN`. Based on the workflow's operations, the `contents: read` permission is sufficient, as the workflow does not use the `GITHUB_TOKEN` for write operations. This change will ensure that the `GITHUB_TOKEN` has restricted access, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
