### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -1,5 +1,8 @@
 name: VPS Dispatch Handler
 
+permissions:
+  contents: read
+
 on:
   repository_dispatch:
     types: [vps-summary-ready]


### PR DESCRIPTION
Potential fix for [https://github.com/clockcrockwork/ccc-summary-dashboard/security/code-scanning/1](https://github.com/clockcrockwork/ccc-summary-dashboard/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only echoes a message and does not perform any actions requiring write access, we will set the permissions to `contents: read`. This ensures the workflow has the minimal permissions necessary to operate securely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
